### PR TITLE
Introduced custome Error messages with `enum AppError` and refactored…

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,18 +1,19 @@
 use crate::domain::{Command, Contact};
+use crate::errors::AppError;
 use std::{
     io::{self, Write},
     num::ParseIntError,
 };
 
 // OUTPUT FUNCTIONS
-pub fn parse_command_from_menu() -> Result<Command, String> {
+pub fn parse_command_from_menu() -> Result<Command, AppError> {
     println!("\n");
     println!("1. Add Contact");
     println!("2. List Contacts");
     println!("3. Delete Contact");
     println!("4. Exit");
     print!("> ");
-    io::stdout().flush().unwrap();
+    io::stdout().flush()?;
 
     let action = get_input();
 
@@ -21,14 +22,15 @@ pub fn parse_command_from_menu() -> Result<Command, String> {
         "2" => Ok(Command::ListContacts),
         "3" => Ok(Command::DeleteContact),
         "4" => Ok(Command::Exit),
-        _ => Err("Invalid command.".to_string()),
+        _ => Err(AppError::ParseCommand(action)),
     }
 }
 
-pub fn confirm_action(action: &str) {
+pub fn confirm_action(action: &str) -> Result<(), AppError> {
     println!("\nAre you sure you want to {}\n? (y/n)", action);
     print!("> ");
-    io::stdout().flush().unwrap();
+    io::stdout().flush()?;
+    Ok(())
 }
 
 pub fn display_contact(contact: &Contact) -> String {

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,5 +1,7 @@
-use crate::store::{ContactStore, Store};
-use std::io;
+use crate::{
+    errors::AppError,
+    store::{ContactStore, Store},
+};
 
 #[derive(Debug, PartialEq)]
 pub struct Contact {
@@ -59,11 +61,11 @@ impl Storage {
 }
 
 impl ContactStore for Storage {
-    fn load(&mut self) -> io::Result<()> {
+    fn load(&mut self) -> Result<(), AppError> {
         self.store.load()
     }
 
-    fn save(&mut self) -> io::Result<()> {
+    fn save(&mut self) -> Result<(), AppError> {
         self.store.save()
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,70 @@
+use core::fmt;
+
+#[derive(Debug)]
+pub enum AppError {
+    Io(std::io::Error),
+    ParseCommand(String),
+    ParseInt(std::num::ParseIntError),
+    Validation(String),
+}
+
+impl From<std::io::Error> for AppError {
+    fn from(err: std::io::Error) -> Self {
+        AppError::Io(err)
+    }
+}
+
+impl From<std::num::ParseIntError> for AppError {
+    fn from(err: std::num::ParseIntError) -> Self {
+        AppError::ParseInt(err)
+    }
+}
+
+impl fmt::Display for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AppError::Io(e) => {
+                write!(f, "I/O error while accessing a file or resource: {}", e)
+            }
+            AppError::ParseCommand(cmd) => {
+                write!(f, "Unrecognized command: '{}'", cmd)
+            }
+            AppError::ParseInt(e) => {
+                write!(f, "Invalid number format: {}", e)
+            }
+            AppError::Validation(msg) => {
+                write!(f, "Validation failed: {}", msg)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::validation::validate_number;
+
+    use super::*;
+
+    #[test]
+    fn confirm_parse_int_error_message() {
+        let wrong_string = "abc".parse::<i32>().unwrap_err();
+        let err = AppError::ParseInt(wrong_string);
+
+        assert!(format!("{}", err).contains("Invalid number format: "));
+    }
+
+    #[test]
+    fn confirm_validation_error() {
+        if !validate_number("abc") {
+            let err = AppError::Validation("\nInvalid Number input.".to_string());
+
+            assert_eq!(
+                format!("{}", err),
+                format!("Validation failed: \nInvalid Number input.")
+            );
+        } else {
+            panic!();
+        }
+    }
+}

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,7 +1,8 @@
 use std::fs::File;
-use std::io::{self, BufRead, BufReader};
+use std::io::{BufRead, BufReader};
 
 use crate::domain::Contact;
+use crate::errors::AppError;
 use crate::validation::{validate_email, validate_name, validate_number};
 
 pub fn serialize_contacts(contacts: &Vec<Contact>) -> String {
@@ -22,7 +23,9 @@ pub fn serialize_contacts(contacts: &Vec<Contact>) -> String {
     data
 }
 
-pub fn deserialize_contacts_from_txt_buffer(buffer: BufReader<File>) -> io::Result<Vec<Contact>> {
+pub fn deserialize_contacts_from_txt_buffer(
+    buffer: BufReader<File>,
+) -> Result<Vec<Contact>, AppError> {
     let mut contacts = Vec::new();
     let mut name = String::new();
     let mut phone = String::new();
@@ -105,9 +108,9 @@ mod tests {
         storage.mem.push(contact1);
         storage.mem.push(contact2);
 
-        storage.save().unwrap();
+        let _ = storage.save();
         storage.mem.clear();
-        storage.load().unwrap();
+        let _ = storage.load();
 
         assert_eq!(
             storage.mem[0],

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod domain;
+mod errors;
 mod helper;
 mod store;
 mod validation;
@@ -8,12 +9,17 @@ use std::io::{self, Write};
 use std::process::exit;
 
 use crate::domain::{Command, Contact, Storage};
+use crate::errors::AppError;
 use crate::store::ContactStore;
 use crate::validation::{contact_exist, validate_email, validate_name, validate_number};
 
 fn main() {
     let mut storage = Storage::new();
-    let _ = storage.load();
+
+    // In case of error
+    if let Err(e) = storage.load() {
+        eprintln!("Unable to load contacts {}", e);
+    }
 
     println!("\n\n--- Contact BOOK ---\n");
 
@@ -34,7 +40,11 @@ fn main() {
                             }
 
                             if !validate_name(&name) {
-                                println!("\nInvalid Name input.");
+                                eprintln!(
+                                    "{}",
+                                    AppError::Validation("\nInvalid Name input.".to_string())
+                                );
+
                                 continue 'add_contact;
                             }
 
@@ -43,7 +53,11 @@ fn main() {
                             let phone = cli::get_input();
 
                             if !validate_number(&phone) {
-                                println!("\nInvalid Number input.");
+                                eprintln!(
+                                    "{}",
+                                    AppError::Validation("\nInvalid Number input.".to_string())
+                                );
+
                                 continue 'add_contact;
                             }
 
@@ -52,7 +66,11 @@ fn main() {
                             let email = cli::get_input();
 
                             if !validate_email(&email) {
-                                println!("\nInvalid email input.");
+                                eprintln!(
+                                    "{}",
+                                    AppError::Validation("\nInvalid email input.".to_string())
+                                );
+
                                 continue 'add_contact;
                             }
 
@@ -69,7 +87,9 @@ fn main() {
                                 "add this contact to your contact list \n{}\n",
                                 cli::display_contact(&new_contact)
                             );
-                            cli::confirm_action(&message);
+                            if let Err(e) = cli::confirm_action(&message) {
+                                eprintln!("{}", e);
+                            }
 
                             let consent = cli::get_input_to_lower();
                             if consent != 'y'.to_string() {
@@ -150,7 +170,9 @@ fn main() {
                                             )
                                         );
 
-                                        cli::confirm_action(&message);
+                                        if let Err(e) = cli::confirm_action(&message) {
+                                            eprintln!("{}", e);
+                                        }
 
                                         let consent = cli::get_input_to_lower();
                                         if consent != 'y'.to_string() {
@@ -169,7 +191,9 @@ fn main() {
                                             "delete this contact from your contact list \n{}\n",
                                             cli::display_contact(&contact_list[indices[0]])
                                         );
-                                        cli::confirm_action(&message);
+                                        if let Err(e) = cli::confirm_action(&message) {
+                                            eprintln!("{}", e);
+                                        }
 
                                         let consent = cli::get_input_to_lower();
                                         if consent != 'y'.to_string() {

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,7 +1,8 @@
 use crate::domain::Contact;
+use crate::errors::AppError;
 use crate::helper;
 use std::fs::{self, File};
-use std::io::{self, BufReader, Write};
+use std::io::{BufReader, Write};
 use std::path::Path;
 
 pub const FILE_PATH: &str = "./.instance/contacts.txt";
@@ -34,13 +35,13 @@ impl Store {
 }
 
 pub trait ContactStore {
-    fn load(&mut self) -> io::Result<()>;
+    fn load(&mut self) -> Result<(), AppError>;
 
-    fn save(&mut self) -> io::Result<()>;
+    fn save(&mut self) -> Result<(), AppError>;
 }
 
 impl ContactStore for Store {
-    fn load(&mut self) -> io::Result<()> {
+    fn load(&mut self) -> Result<(), AppError> {
         // Read text from file
         let file = File::open(FILE_PATH)?;
         let reader = BufReader::new(file);
@@ -49,7 +50,7 @@ impl ContactStore for Store {
         Ok(())
     }
 
-    fn save(&mut self) -> io::Result<()> {
+    fn save(&mut self) -> Result<(), AppError> {
         let data = helper::serialize_contacts(&self.mem);
         self.file.write_all(data.as_bytes())?;
 


### PR DESCRIPTION
… all use of `io::Result Error` and `.unwrap()` to use the unified costume AppError